### PR TITLE
hoverクラスをpc用とsp,tb用に切り分け

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,22 +61,28 @@
         <p>CSSアニメーションとJavaScriptで<br />動きを実装しています</p>
       </div>
       <div class="contents__container">
-        <a class="contents__item bg-main" href="./pages/hamburgermenu.html"
+        <a
+          class="contents__item bg-color-main"
+          href="./pages/hamburgermenu.html"
           ><h3>ハンバーガー<br />メニュー</h3></a
         >
-        <a class="contents__item bg-main" href="./pages/accordionmenu.html"
+        <a
+          class="contents__item bg-color-main"
+          href="./pages/accordionmenu.html"
           ><h3>アコーディオン<br />メニュー</h3></a
         >
-        <a class="contents__item bg-main" href="./pages/modalwindow.html"
+        <a class="contents__item bg-color-main" href="./pages/modalwindow.html"
           ><h3>モーダル<br />ウィンドウ</h3></a
         >
-        <a class="contents__item bg-main" href="./pages/tooltip.html"
+        <a class="contents__item bg-color-main" href="./pages/tooltip.html"
           ><h3>ツールチップ</h3></a
         >
-        <a class="contents__item bg-main" href="./pages/loadinganimation.html"
+        <a
+          class="contents__item bg-color-main"
+          href="./pages/loadinganimation.html"
           ><h3>ローディング<br />アニメーション</h3></a
         >
-        <a class="contents__item bg-main" href="./pages/cssanimation.html"
+        <a class="contents__item bg-color-main" href="./pages/cssanimation.html"
           ><h3>その他のCSS<br />アニメーション</h3></a
         >
       </div>

--- a/index.html
+++ b/index.html
@@ -64,37 +64,25 @@
         <a
           class="contents__item bg-color-main"
           href="./pages/hamburgermenu.html"
-          ontouchstart=""
           ><h3>ハンバーガー<br />メニュー</h3></a
         >
         <a
           class="contents__item bg-color-main"
           href="./pages/accordionmenu.html"
-          ontouchstart=""
           ><h3>アコーディオン<br />メニュー</h3></a
         >
-        <a
-          class="contents__item bg-color-main"
-          href="./pages/modalwindow.html"
-          ontouchstart=""
+        <a class="contents__item bg-color-main" href="./pages/modalwindow.html"
           ><h3>モーダル<br />ウィンドウ</h3></a
         >
-        <a
-          class="contents__item bg-color-main"
-          href="./pages/tooltip.html"
-          ontouchstart=""
+        <a class="contents__item bg-color-main" href="./pages/tooltip.html"
           ><h3>ツールチップ</h3></a
         >
         <a
           class="contents__item bg-color-main"
           href="./pages/loadinganimation.html"
-          ontouchstart=""
           ><h3>ローディング<br />アニメーション</h3></a
         >
-        <a
-          class="contents__item bg-color-main"
-          href="./pages/cssanimation.html"
-          ontouchstart=""
+        <a class="contents__item bg-color-main" href="./pages/cssanimation.html"
           ><h3>その他のCSS<br />アニメーション</h3></a
         >
       </div>

--- a/index.html
+++ b/index.html
@@ -64,25 +64,37 @@
         <a
           class="contents__item bg-color-main"
           href="./pages/hamburgermenu.html"
+          ontouchstart=""
           ><h3>ハンバーガー<br />メニュー</h3></a
         >
         <a
           class="contents__item bg-color-main"
           href="./pages/accordionmenu.html"
+          ontouchstart=""
           ><h3>アコーディオン<br />メニュー</h3></a
         >
-        <a class="contents__item bg-color-main" href="./pages/modalwindow.html"
+        <a
+          class="contents__item bg-color-main"
+          href="./pages/modalwindow.html"
+          ontouchstart=""
           ><h3>モーダル<br />ウィンドウ</h3></a
         >
-        <a class="contents__item bg-color-main" href="./pages/tooltip.html"
+        <a
+          class="contents__item bg-color-main"
+          href="./pages/tooltip.html"
+          ontouchstart=""
           ><h3>ツールチップ</h3></a
         >
         <a
           class="contents__item bg-color-main"
           href="./pages/loadinganimation.html"
+          ontouchstart=""
           ><h3>ローディング<br />アニメーション</h3></a
         >
-        <a class="contents__item bg-color-main" href="./pages/cssanimation.html"
+        <a
+          class="contents__item bg-color-main"
+          href="./pages/cssanimation.html"
+          ontouchstart=""
           ><h3>その他のCSS<br />アニメーション</h3></a
         >
       </div>

--- a/pages/cssanimation.html
+++ b/pages/cssanimation.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../css/cssanimation.css" />
     <script src="https://unpkg.com/akar-icons-fonts"></script>
   </head>
-  <body id="body">
+  <body id="body" ontouchstart="">
     <header class="header">
       <a class="rogo" href="../index.html">Webデザイン<br />パーツ集</a>
       <nav>
@@ -59,15 +59,15 @@
         <div class="contents__container" ontouchstart="">
           <div class="contents__item">
             <h3>テキスト-1</h3>
-            <div class="cssanimation-text text-1">hello</div>
+            <div class="cssanimation-text text-1" ontouchstart="">hello</div>
           </div>
           <div class="contents__item">
             <h3>テキスト-2</h3>
-            <div class="cssanimation-text text-2">hello</div>
+            <div class="cssanimation-text text-2" ontouchstart="">hello</div>
           </div>
           <div class="contents__item">
             <h3>テキスト-3</h3>
-            <div class="cssanimation-text text-3"></div>
+            <div class="cssanimation-text text-3" ontouchstart=""></div>
           </div>
         </div>
       </section>

--- a/pages/tooltip.html
+++ b/pages/tooltip.html
@@ -57,8 +57,6 @@
           <h2>ツールチップ</h2>
         </div>
         <div class="contents__container">
-          <!-- TODO: sp,tbでは確認できない旨を追記する
-          ２つ目と３つ目は長押しすれば確認できるが、別の要素をホバーしないと消せない -->
           <div class="contents__item">
             <h3>title属性を使用<br />※PCのみ</h3>
             <p class="tooltip-1" title="テキスト">テキスト</p>

--- a/pages/tooltip.html
+++ b/pages/tooltip.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="../css/tooltip.css" />
     <script src="https://unpkg.com/akar-icons-fonts"></script>
   </head>
-  <body id="body">
+  <body id="body" ontouchstart="">
     <header class="header">
       <a class="rogo" href="../index.html">Webデザイン<br />パーツ集</a>
       <nav>
@@ -57,21 +57,21 @@
           <h2>ツールチップ</h2>
         </div>
         <div class="contents__container">
-          <!-- TODO: title属性について調べてみる
-          読み上げ機能の対象ではないみたい-->
           <!-- TODO: sp,tbでは確認できない旨を追記する
           ２つ目と３つ目は長押しすれば確認できるが、別の要素をホバーしないと消せない -->
           <div class="contents__item">
-            <h3>title属性を使用</h3>
+            <h3>title属性を使用<br />※PCのみ</h3>
             <p class="tooltip-1" title="テキスト">テキスト</p>
           </div>
           <div class="contents__item">
             <h3>下部に表示</h3>
-            <p class="tooltip-2" data-tooltip="テキスト">テキスト</p>
+            <p class="tooltip-2" data-tooltip="テキスト" ontouchstart="">
+              テキスト
+            </p>
           </div>
           <div class="contents__item">
             <h3>上部に表示</h3>
-            <div class="tooltip-3">
+            <div class="tooltip-3" ontouchstart="">
               <p>テキスト</p>
               <div class="description1">テキスト</div>
             </div>

--- a/pages/tooltip.html
+++ b/pages/tooltip.html
@@ -67,10 +67,7 @@
           </div>
           <div class="contents__item">
             <h3>下部に表示</h3>
-            <input type="checkbox" id="tooltip_2" />
-            <label for="tooltip_2">
-              <p class="tooltip-2" data-tooltip="テキスト">テキスト</p>
-            </label>
+            <p class="tooltip-2" data-tooltip="テキスト">テキスト</p>
           </div>
           <div class="contents__item">
             <h3>上部に表示</h3>

--- a/pages/tooltip.html
+++ b/pages/tooltip.html
@@ -67,8 +67,10 @@
           </div>
           <div class="contents__item">
             <h3>下部に表示</h3>
-            <input type="checkbox" />
-            <p class="tooltip-2" data-tooltip="テキスト">テキスト</p>
+            <input type="checkbox" id="tooltip_2" />
+            <label for="tooltip_2">
+              <p class="tooltip-2" data-tooltip="テキスト">テキスト</p>
+            </label>
           </div>
           <div class="contents__item">
             <h3>上部に表示</h3>

--- a/pages/tooltip.html
+++ b/pages/tooltip.html
@@ -67,6 +67,7 @@
           </div>
           <div class="contents__item">
             <h3>下部に表示</h3>
+            <input type="checkbox" />
             <p class="tooltip-2" data-tooltip="テキスト">テキスト</p>
           </div>
           <div class="contents__item">

--- a/scss/cssanimation.scss
+++ b/scss/cssanimation.scss
@@ -13,22 +13,22 @@
 // TODO: spではタップ中のみ変化するようにしたが微妙？
 .text-1 {
   color: $color-accent;
-  // &:hover {
-  //   animation: hop 1s;
-  //   color: $color-main;
+  &:hover {
+    animation: hop 1s;
+    color: $color-main;
+  }
+  // @media (hover: hover) {
+  //   &:hover {
+  //     animation: hop 1s;
+  //     color: $color-main;
+  //   }
   // }
-  @media (hover: hover) {
-    &:hover {
-      animation: hop 1s;
-      color: $color-main;
-    }
-  }
-  @media (hover: none) {
-    &:active {
-      animation: hop 1s;
-      color: $color-main;
-    }
-  }
+  // @media (hover: none) {
+  //   &:active {
+  //     animation: hop 1s;
+  //     color: $color-main;
+  //   }
+  // }
 }
 
 .text-2 {
@@ -46,28 +46,28 @@
     border-radius: 5px;
     transition: ease 0.4s;
   }
-  // &:hover {
-  //   color: $color-base;
-  //   &::after {
-  //     animation: liner 0.5s forwards;
+  &:hover {
+    color: $color-base;
+    &::after {
+      animation: liner 0.5s forwards;
+    }
+  }
+  // @media (hover: hover) {
+  //   &:hover {
+  //     color: $color-base;
+  //     &::after {
+  //       animation: liner 0.5s forwards;
+  //     }
   //   }
   // }
-  @media (hover: hover) {
-    &:hover {
-      color: $color-base;
-      &::after {
-        animation: liner 0.5s forwards;
-      }
-    }
-  }
-  @media (hover: none) {
-    &:active {
-      color: $color-base;
-      &::after {
-        animation: liner 0.5s forwards;
-      }
-    }
-  }
+  // @media (hover: none) {
+  //   &:active {
+  //     color: $color-base;
+  //     &::after {
+  //       animation: liner 0.5s forwards;
+  //     }
+  //   }
+  // }
 }
 
 .text-3 {
@@ -77,31 +77,31 @@
   &::before {
     content: "hello";
   }
-  // &:hover {
-  //   transform: rotateX(360deg);
-  //   background-color: $color-main;
-  //   &::before {
-  //     content: "bye";
+  &:hover {
+    transform: rotateX(360deg);
+    background-color: $color-main;
+    &::before {
+      content: "bye";
+    }
+  }
+  // @media (hover: hover) {
+  //   &:hover {
+  //     transform: rotateX(360deg);
+  //     background-color: $color-main;
+  //     &::before {
+  //       content: "bye";
+  //     }
   //   }
   // }
-  @media (hover: hover) {
-    &:hover {
-      transform: rotateX(360deg);
-      background-color: $color-main;
-      &::before {
-        content: "bye";
-      }
-    }
-  }
-  @media (hover: none) {
-    &:active {
-      transform: rotateX(360deg);
-      background-color: $color-main;
-      &::before {
-        content: "bye";
-      }
-    }
-  }
+  // @media (hover: none) {
+  //   &:active {
+  //     transform: rotateX(360deg);
+  //     background-color: $color-main;
+  //     &::before {
+  //       content: "bye";
+  //     }
+  //   }
+  // }
 }
 
 // アニメーション

--- a/scss/cssanimation.scss
+++ b/scss/cssanimation.scss
@@ -10,7 +10,7 @@
   cursor: pointer;
 }
 
-// TODO: spではタップすれば確認できるが、再タップでは元に戻らない
+// TODO: spではタップ中のみ変化するようにしたが微妙？
 .text-1 {
   color: $color-accent;
   // &:hover {

--- a/scss/cssanimation.scss
+++ b/scss/cssanimation.scss
@@ -10,25 +10,12 @@
   cursor: pointer;
 }
 
-// TODO: spではタップ中のみ変化するようにしたが微妙？
 .text-1 {
   color: $color-accent;
   &:hover {
     animation: hop 1s;
     color: $color-main;
   }
-  // @media (hover: hover) {
-  //   &:hover {
-  //     animation: hop 1s;
-  //     color: $color-main;
-  //   }
-  // }
-  // @media (hover: none) {
-  //   &:active {
-  //     animation: hop 1s;
-  //     color: $color-main;
-  //   }
-  // }
 }
 
 .text-2 {
@@ -52,22 +39,6 @@
       animation: liner 0.5s forwards;
     }
   }
-  // @media (hover: hover) {
-  //   &:hover {
-  //     color: $color-base;
-  //     &::after {
-  //       animation: liner 0.5s forwards;
-  //     }
-  //   }
-  // }
-  // @media (hover: none) {
-  //   &:active {
-  //     color: $color-base;
-  //     &::after {
-  //       animation: liner 0.5s forwards;
-  //     }
-  //   }
-  // }
 }
 
 .text-3 {
@@ -84,24 +55,6 @@
       content: "bye";
     }
   }
-  // @media (hover: hover) {
-  //   &:hover {
-  //     transform: rotateX(360deg);
-  //     background-color: $color-main;
-  //     &::before {
-  //       content: "bye";
-  //     }
-  //   }
-  // }
-  // @media (hover: none) {
-  //   &:active {
-  //     transform: rotateX(360deg);
-  //     background-color: $color-main;
-  //     &::before {
-  //       content: "bye";
-  //     }
-  //   }
-  // }
 }
 
 // アニメーション

--- a/scss/cssanimation.scss
+++ b/scss/cssanimation.scss
@@ -13,18 +13,27 @@
 // TODO: spではタップすれば確認できるが、再タップでは元に戻らない
 .text-1 {
   color: $color-accent;
-  &:hover {
-    animation: hop 1s;
-    color: $color-main;
+  // &:hover {
+  //   animation: hop 1s;
+  //   color: $color-main;
+  // }
+  @media (hover: hover) {
+    &:hover {
+      animation: hop 1s;
+      color: $color-main;
+    }
+  }
+  @media (hover: none) {
+    &:active {
+      animation: hop 1s;
+      color: $color-main;
+    }
   }
 }
 
 .text-2 {
   position: relative;
   color: $color-accent;
-  &:hover {
-    color: $color-base;
-  }
   &::after {
     content: "";
     position: absolute;
@@ -37,8 +46,27 @@
     border-radius: 5px;
     transition: ease 0.4s;
   }
-  &:hover::after {
-    animation: liner 0.5s forwards;
+  // &:hover {
+  //   color: $color-base;
+  //   &::after {
+  //     animation: liner 0.5s forwards;
+  //   }
+  // }
+  @media (hover: hover) {
+    &:hover {
+      color: $color-base;
+      &::after {
+        animation: liner 0.5s forwards;
+      }
+    }
+  }
+  @media (hover: none) {
+    &:active {
+      color: $color-base;
+      &::after {
+        animation: liner 0.5s forwards;
+      }
+    }
   }
 }
 
@@ -46,15 +74,33 @@
   color: $color-base;
   background-color: $color-accent;
   border-radius: 5px;
-  &:hover {
-    transform: rotateX(360deg);
-    background-color: $color-main;
-  }
   &::before {
     content: "hello";
   }
-  &:hover::before {
-    content: "bye";
+  // &:hover {
+  //   transform: rotateX(360deg);
+  //   background-color: $color-main;
+  //   &::before {
+  //     content: "bye";
+  //   }
+  // }
+  @media (hover: hover) {
+    &:hover {
+      transform: rotateX(360deg);
+      background-color: $color-main;
+      &::before {
+        content: "bye";
+      }
+    }
+  }
+  @media (hover: none) {
+    &:active {
+      transform: rotateX(360deg);
+      background-color: $color-main;
+      &::before {
+        content: "bye";
+      }
+    }
   }
 }
 

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -18,7 +18,7 @@
   }
 }
 
-.bg-main:hover {
+.bg-color-main:hover {
   background-color: $color-main;
   color: $color-base;
 }

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -57,32 +57,6 @@
   &:hover::after {
     top: 34px;
   }
-  // @media (hover: hover) {
-  //   &:hover::before,
-  //   &:hover::after {
-  //     opacity: 1;
-  //     visibility: visible;
-  //   }
-  //   &:hover::before {
-  //     top: 14px;
-  //   }
-  //   &:hover::after {
-  //     top: 34px;
-  //   }
-  // }
-  // @media (hover: none) {
-  //   &:active::before,
-  //   &:active::after {
-  //     opacity: 1;
-  //     visibility: visible;
-  //   }
-  //   &:active::before {
-  //     top: 14px;
-  //   }
-  //   &:active::after {
-  //     top: 34px;
-  //   }
-  // }
 }
 
 // テキストとツールチップを別要素で管理

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -71,12 +71,12 @@
     }
   }
   @media (hover: none) {
-    input:checked + &::before {
+    #tooltip_2:checked + &::before {
       opacity: 1;
       visibility: visible;
       top: 14px;
     }
-    input:checked + &::after {
+    #tooltip_2:checked + &::after {
       opacity: 1;
       visibility: visible;
       top: 34px;

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -46,16 +46,41 @@
     z-index: 1;
   }
   /* マウスホバーしたときの設定 */
-  &:hover::before,
-  &:hover::after {
-    opacity: 1;
-    visibility: visible;
+  // &:hover::before,
+  // &:hover::after {
+  //   opacity: 1;
+  //   visibility: visible;
+  // }
+  // &:hover::before {
+  //   top: 14px;
+  // }
+  // &:hover::after {
+  //   top: 34px;
+  // }
+  @media (hover: hover) {
+    &:hover::before,
+    &:hover::after {
+      opacity: 1;
+      visibility: visible;
+    }
+    &:hover::before {
+      top: 14px;
+    }
+    &:hover::after {
+      top: 34px;
+    }
   }
-  &:hover::before {
-    top: 14px;
-  }
-  &:hover::after {
-    top: 34px;
+  @media (hover: none) {
+    input:checked + &::before {
+      opacity: 1;
+      visibility: visible;
+      top: 14px;
+    }
+    input:checked + &::after {
+      opacity: 1;
+      visibility: visible;
+      top: 34px;
+    }
   }
 }
 

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -71,14 +71,15 @@
     }
   }
   @media (hover: none) {
-    #tooltip_2:checked + &::before {
+    &:active::before,
+    &:active::after {
       opacity: 1;
       visibility: visible;
+    }
+    &:active::before {
       top: 14px;
     }
-    #tooltip_2:checked + &::after {
-      opacity: 1;
-      visibility: visible;
+    &:active::after {
       top: 34px;
     }
   }

--- a/scss/tooltip.scss
+++ b/scss/tooltip.scss
@@ -46,43 +46,43 @@
     z-index: 1;
   }
   /* マウスホバーしたときの設定 */
-  // &:hover::before,
-  // &:hover::after {
-  //   opacity: 1;
-  //   visibility: visible;
-  // }
-  // &:hover::before {
-  //   top: 14px;
-  // }
-  // &:hover::after {
-  //   top: 34px;
-  // }
-  @media (hover: hover) {
-    &:hover::before,
-    &:hover::after {
-      opacity: 1;
-      visibility: visible;
-    }
-    &:hover::before {
-      top: 14px;
-    }
-    &:hover::after {
-      top: 34px;
-    }
+  &:hover::before,
+  &:hover::after {
+    opacity: 1;
+    visibility: visible;
   }
-  @media (hover: none) {
-    &:active::before,
-    &:active::after {
-      opacity: 1;
-      visibility: visible;
-    }
-    &:active::before {
-      top: 14px;
-    }
-    &:active::after {
-      top: 34px;
-    }
+  &:hover::before {
+    top: 14px;
   }
+  &:hover::after {
+    top: 34px;
+  }
+  // @media (hover: hover) {
+  //   &:hover::before,
+  //   &:hover::after {
+  //     opacity: 1;
+  //     visibility: visible;
+  //   }
+  //   &:hover::before {
+  //     top: 14px;
+  //   }
+  //   &:hover::after {
+  //     top: 34px;
+  //   }
+  // }
+  // @media (hover: none) {
+  //   &:active::before,
+  //   &:active::after {
+  //     opacity: 1;
+  //     visibility: visible;
+  //   }
+  //   &:active::before {
+  //     top: 14px;
+  //   }
+  //   &:active::after {
+  //     top: 34px;
+  //   }
+  // }
 }
 
 // テキストとツールチップを別要素で管理


### PR DESCRIPTION
## やったこと
- tooltip.scsslのhoverクラスのあたっている箇所をsp,tbでも自然に動作するように変更した
- 変更対象ページ: index, cssanimation, tooltip
- 他２ページは未対応だが、tooltipのデプロイプレビューを確認するため先行してプルリクを発行する